### PR TITLE
Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install puncturedfem
 ```
 
 ### Dependencies
-This project is written in Python 3.11 and uses the following packages:
+This project requires Python 3.9 or higher and uses the following packages:
 - [matplotlib](https://matplotlib.org/) (plotting)
 - [numba](https://numba.pydata.org/) (just-in-time compilation)
 - [numpy](https://numpy.org/) (arrays, FFT)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## [v0.4.5]
+### Maintenance
+- [x] change dependency: Python 3.9 (was 3.11)
+- [x] change dependency: `scipy` 1.12 (was 1.11)
+- [x] change: use `rtol` keyword argument in `scipy.sparse.linalg.gmres` to `tol`
+- [x] fix: missing type annotations for tests
+- [x] fix: use `Union` for type hints rather than ` | ` operator (to support Python 3.9)
+
+
 ## [v0.4.4] - 2024 Mar 07
 ### Documentation
 - [x] change: `README.md`

--- a/puncturedfem/__init__.py
+++ b/puncturedfem/__init__.py
@@ -84,7 +84,6 @@ __all__ = [
     "meshlib",
     "mesh_builder",
     "split_edge",
-
     # locfun
     "DirichletTrace",
     "EdgeSpace",
@@ -95,12 +94,10 @@ __all__ = [
     "PiecewisePolynomial",
     "barycentric_coordinates",
     "barycentric_coordinates_edge",
-
     # solver
     "GlobalFunctionSpace",
     "BilinearForm",
     "Solver",
-
     # plot
     "plot",
 ]

--- a/puncturedfem/locfun/nystrom.py
+++ b/puncturedfem/locfun/nystrom.py
@@ -177,7 +177,7 @@ class NystromSolver:
     def _gmres_solve(
         self, A: LinearOperator, b: np.ndarray, M: LinearOperator
     ) -> np.ndarray:
-        x, flag = gmres(A=A, b=b, M=M, atol=1e-12, tol=1e-12)
+        x, flag = gmres(A=A, b=b, M=M, atol=1e-12, rtol=1e-12)
         if flag > 0:
             r = b - A @ x
             print(

--- a/puncturedfem/locfun/nystrom.py
+++ b/puncturedfem/locfun/nystrom.py
@@ -357,9 +357,9 @@ class NystromSolver:
             for j in range(self.K.num_holes + 1):
                 jj1 = self.K.component_start_idx[j]
                 jj2 = self.K.component_start_idx[j + 1]
-                self.single_layer_mat[ii1:ii2, jj1:jj2] = (
-                    self.single_layer_component_block(i, j)
-                )
+                self.single_layer_mat[
+                    ii1:ii2, jj1:jj2
+                ] = self.single_layer_component_block(i, j)
 
     def single_layer_component_block(self, i: int, j: int) -> np.ndarray:
         """
@@ -470,10 +470,10 @@ class NystromSolver:
             for j in range(self.K.num_holes + 1):
                 jj1 = self.K.component_start_idx[j]
                 jj2 = self.K.component_start_idx[j + 1]
-                self.double_layer_mat[ii1:ii2, jj1:jj2] = (
-                    self.double_layer_component_block(
-                        self.K.components[i], self.K.components[j]
-                    )
+                self.double_layer_mat[
+                    ii1:ii2, jj1:jj2
+                ] = self.double_layer_component_block(
+                    self.K.components[i], self.K.components[j]
                 )
 
     def double_layer_component_block(

--- a/puncturedfem/mesh/closed_contour.py
+++ b/puncturedfem/mesh/closed_contour.py
@@ -154,9 +154,9 @@ class ClosedContour:
         # is the starting point of the next Edge
         self.closest_vert_idx = np.zeros((self.num_pts,), dtype=int)
         for i in range(self.num_edges):
-            self.closest_vert_idx[self.vert_idx[i] : mid_idx[i]] = (
-                self.vert_idx[i]
-            )
+            self.closest_vert_idx[
+                self.vert_idx[i] : mid_idx[i]
+            ] = self.vert_idx[i]
             self.closest_vert_idx[mid_idx[i] : self.vert_idx[i + 1]] = (
                 self.vert_idx[i + 1] % self.num_pts
             )

--- a/puncturedfem/mesh/quad.py
+++ b/puncturedfem/mesh/quad.py
@@ -148,7 +148,9 @@ class Quad:
         denom = cp + (1 - c) ** p
 
         self.t = (2 * np.pi) * cp / denom
-        self.wgt = (3 * (p - 2) * s2 + 2) * (c * (1 - c)) ** (p - 1) / denom**2
+        self.wgt = (
+            (3 * (p - 2) * s2 + 2) * (c * (1 - c)) ** (p - 1) / denom**2
+        )
 
     def martensen(self) -> None:
         """

--- a/puncturedfem/mesh/split_edge.py
+++ b/puncturedfem/mesh/split_edge.py
@@ -16,9 +16,11 @@ from .vert import Vert
 
 def split_edge(
     e: Edge,
-    t_split: Optional[Union[int, float, list[int | float], np.ndarray]] = None,
+    t_split: Optional[
+        Union[int, float, list[Union[int, float]], np.ndarray]
+    ] = None,
     num_edges: Optional[int] = None,
-) -> list[Edge] | tuple[Edge, Edge]:
+) -> Union[list[Edge], tuple[Edge, Edge]]:
     """
     Splits the edge e at the parameter t_split and returns the resulting edges.
     If t_split is a list of parameters, the edge is split at each parameter in

--- a/puncturedfem/plot/trace_plot.py
+++ b/puncturedfem/plot/trace_plot.py
@@ -32,7 +32,7 @@ class TracePlot:
     x_ticks: np.ndarray
     x_labels: list[str]
     num_pts: int
-    fmt: str | list[str]
+    fmt: Union[str, list[str]]
     legend: tuple
     title: str
     log_scale: bool
@@ -43,7 +43,7 @@ class TracePlot:
         traces: Union[TraceLike, list[TraceLike]],
         K: MeshCell,
         quad_dict: dict[str, Quad],
-        fmt: str | list[str] = "k-",
+        fmt: Union[str, list[str]] = "k-",
         legend: tuple = (),
         title: str = "",
         log_scale: bool = False,
@@ -142,7 +142,7 @@ class TracePlot:
                 )
             self.traces.append(f)
 
-    def set_format(self, fmt: str | list[str]) -> None:
+    def set_format(self, fmt: Union[str, list[str]]) -> None:
         """
         Sets the format string(s) used to plot the traces.
         """
@@ -193,7 +193,7 @@ class TracePlot:
                     "traces"
                 )
 
-    def _validate_format(self, fmt: str | list[str]) -> None:
+    def _validate_format(self, fmt: Union[str, list[str]]) -> None:
         if isinstance(fmt, str):
             pass
         elif isinstance(fmt, list):
@@ -205,7 +205,9 @@ class TracePlot:
         else:
             raise TypeError("fmt must be a string or a list of strings")
 
-    def _validate_traces(self, traces: np.ndarray | list[np.ndarray]) -> None:
+    def _validate_traces(
+        self, traces: Union[np.ndarray, list[np.ndarray]]
+    ) -> None:
         if isinstance(traces, np.ndarray):
             if len(traces) != self.num_pts:
                 raise ValueError(

--- a/puncturedfem/solver/solver.py
+++ b/puncturedfem/solver/solver.py
@@ -6,6 +6,8 @@ Module containing the Solver class, which is a convenience class for solving
 the global linear system.
 """
 
+from typing import Union
+
 from numpy import ndarray, shape, zeros
 from scipy.sparse import csr_matrix
 from scipy.sparse.linalg import spsolve
@@ -215,7 +217,7 @@ class Solver:
             # loop over local functions
             loc_basis = V_K.get_basis()
 
-            range_num_funs: range | tqdm[int]
+            range_num_funs: Union[range, tqdm[int]]
             if verbose:
                 range_num_funs = tqdm(range(V_K.num_funs))
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.11"
 matplotlib = "^3.8.0"
 numba = "^0.59.1"
 numpy = "^1.26.0"
-scipy = "^1.11.2"
+scipy = "^1.12.0"
 tqdm = "^4.66.1"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "puncturedfem"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Sam Reynolds <sreyn@proton.me>"]
 description = "A finite element method on meshes with curvilinear and multiply connected cells."
 readme = "README.md"
@@ -8,6 +8,7 @@ license = "GNU General Public License v3.0"
 packages = [{include = "puncturedfem"}]
 
 [tool.poetry.dependencies]
+deprecated = "^1.2.14"
 python = "^3.11"
 matplotlib = "^3.8.0"
 numba = "^0.59.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ license = "GNU General Public License v3.0"
 packages = [{include = "puncturedfem"}]
 
 [tool.poetry.dependencies]
+python = "^3.9"
 deprecated = "^1.2.14"
-python = "^3.11"
 matplotlib = "^3.8.0"
 numba = "^0.59.1"
 numpy = "^1.26.0"

--- a/tests/build_cell.py
+++ b/tests/build_cell.py
@@ -129,7 +129,7 @@ def build_punctured_square(
     return K, cell_data
 
 
-def build_ghost():
+def build_ghost() -> pf.MeshCell:
     """Make the ghosty boi"""
 
     # define vertices

--- a/tests/test_int_val.py
+++ b/tests/test_int_val.py
@@ -14,7 +14,7 @@ from .build_cell import build_ghost
 TOL = 1e-10
 
 
-def test_int_val_ghost():
+def test_int_val_ghost() -> None:
     """Verify correct interior values from Example 1.C"""
     # build mesh cell
     K = build_ghost()
@@ -42,7 +42,7 @@ def test_int_val_ghost():
     )
 
     # Laplacian of v
-    v_laplacian = pf.Polynomial([[6.0, 1, 1], [2.0, 0, 0]])
+    v_laplacian = pf.Polynomial([(6.0, 1, 1), (2.0, 0, 0)])
 
     # store v as a local function object
     v = pf.LocalFunction(nyst=nyst, lap_poly=v_laplacian, has_poly_trace=False)


### PR DESCRIPTION
### Maintenance
- [x] change dependency: Python 3.9 (was 3.11)
- [x] change dependency: `scipy` 1.12 (was 1.11)
- [x] change: use `rtol` keyword argument in `scipy.sparse.linalg.gmres` to `tol`
- [x] fix: missing type annotations for tests
- [x] fix: use `Union` for type hints rather than ` | ` operator (to support Python 3.9)